### PR TITLE
Add optional macro for non-default sink name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Supported Logging Backends
 - `io:format/2` as the default
 - no-op logging via `-DHUT_NONE`
 - SASL error_logger via `-DHUT_ERROR_LOGGER`
-- [Lager](https://github.com/basho/lager) via `-DHUT_LAGER`
+- [Lager](https://github.com/basho/lager) via `-DHUT_LAGER` (you may optionally specify a different log message sink by additionally defining `-DHUT_LAGER_SINK mysinkname`; the default message sink is `lager`)
 - custom callback module via `-DHUT_CUSTOM -DHUT_CUSTOM_CB mycbmod` (the module must provide the function `log(Level, Fmt, Args, Opts)`
 
 Examples

--- a/include/hut.hrl
+++ b/include/hut.hrl
@@ -13,9 +13,13 @@
 -ifdef(HUT_LAGER).
 -define(log_type, "lager").
 
--define(log(__Level, __Fmt), lager:__Level([], __Fmt, [])).
--define(log(__Level, __Fmt, __Args), lager:__Level([], __Fmt, __Args)).
--define(log(__Level, __Fmt, __Args, __Opts), lager:__Level(__Opts, __Fmt, __Args)).
+-ifndef(HUT_LAGER_SINK)
+-define(HUT_LAGER_SINK, lager).
+-endif.
+
+-define(log(__Level, __Fmt), ?HUT_LAGER_SINK:__Level([], __Fmt, [])).
+-define(log(__Level, __Fmt, __Args), ?HUT_LAGER_SINK:__Level([], __Fmt, __Args)).
+-define(log(__Level, __Fmt, __Args, __Opts), ?HUT_LAGER_SINK:__Level(__Opts, __Fmt, __Args)).
 
 -else.
 


### PR DESCRIPTION
Lager 3.x has a feature to route log messages to a different gen_event
handler than the default lager event handler if configured and running.
