### PR TITLE
add hexer.mk to the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /hut.d
 /deps
 /.erlang.mk
+hexer
+hexer.config

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ PROJECT = hut
 PROJECT_DESCRIPTION = helper library for making Erlang libraries logging framework agnostic
 PROJECT_VERSION = 1.1.0
 
+BUILD_DEPS = hexer_mk
+dep_hexer_mk = git https://github.com/inaka/hexer.mk.git 1.1.0
+DEP_PLUGINS = hexer_mk
+
 ifneq (,$(filter $(shell uname -s),FreeBSD DragonFly))
 make = gmake
 else

--- a/src/hut.app.src
+++ b/src/hut.app.src
@@ -1,7 +1,7 @@
 %% -*- erlang -*-
 {application, hut, [
   {description, "helper library for making Erlang libraries logging framework agnostic"},
-  {vsn, git},
+  {vsn, "1.1.0"},
   {registered, []},
   {applications, [kernel, stdlib]},
   {modules, []},

--- a/src/hut.app.src
+++ b/src/hut.app.src
@@ -6,5 +6,9 @@
   {applications, [kernel, stdlib]},
   {modules, []},
   {mod, []},
-  {env, []}
+  {env, []},
+  {maintainers, ["tolbrino"]},
+  {licenses, ["MIT"]},
+  {links, [{"Github", "https://github.com/tolbrino/hut"}]},
+  {build_tools, ["erlang.mk"]}
 ]}.


### PR DESCRIPTION
This if my first attempt at addressing #2 

When I tried to test this out by actually publishing the package I got [an error](https://github.com/inaka/hexer.mk/issues/21) that I haven't been able to resolve. It looks like the package [exists on hex.pm now](https://hex.pm/packages?search=hut&sort=downloads), but there are no downloadable versions.

Once I get this working I'll happily add you as the owner to the package.
