### PR TITLE
Remove mod specification causing reltool crash

### DIFF
--- a/src/hut.app.src
+++ b/src/hut.app.src
@@ -6,7 +6,6 @@
   {registered, []},
   {applications, [kernel, stdlib]},
   {modules, []},
-  {mod, []},
   {env, []},
   {maintainers, ["tolbrino"]},
   {licenses, ["MIT"]},


### PR DESCRIPTION
Callback module specification for hut, causes building release (with hut library as a dependency) to fail:

`{"init terminating in do_boot",{{case_clause,[]},[{reltool_server,refresh_app,3,[{file,"src/reltool_server.erl"},{line,1032}]},{reltool_server,refresh_apps,5,[{file,"src/reltool_server.erl"},{line,1992}]},{reltool_server,refresh,1,[{file,"src/reltool_server.erl"},{line,1627}]},{reltool_server,do_init,1,[{file,"src/reltool_server.erl"},{line,155}]},{reltool_server,init,1,[{file,"src/reltool_server.erl"},{line,133}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,237}]}]}}
`
because it is expecting `undefined` or not empty list.

According to **Erlang** documentation:

> mod
> Specifies the application callback module and a start argument, see application(3).
> 
> The mod key is necessary for an application implemented as a supervision tree, or the application controller will not know how to start it. The mod key can be omitted for applications without processes, typically code libraries such as the application STDLIB.
