### PR TITLE
Remove default app attributes

### DIFF
--- a/src/hut.app.src
+++ b/src/hut.app.src
@@ -6,7 +6,6 @@
   {registered, []},
   {applications, [kernel, stdlib]},
   {modules, []},
-  {mod, []},
   {env, []},
   {maintainers, ["tolbrino"]},
   {licenses, ["MIT"]},


### PR DESCRIPTION
These attributes cause problems when hut is included into a release, using Relx (and by extension systools). See https://github.com/erlware/relx/issues/18
