### PR TITLE
Add preprocessor options to HUT_CUSTOM_CB usage.

### DIFF
--- a/include/hut.hrl
+++ b/include/hut.hrl
@@ -68,12 +68,19 @@
 -ifdef(HUT_CUSTOM_CB).
 -define(log_type, "custom").
 
+-ifndef(FUNCTION_NAME).
+-define(FUNCTION_NAME, undefined).
+-endif.
+-ifndef(FUNCTION_ARITY).
+-define(FUNCTION_ARITY, undefined).
+-endif.
+
 -define(log(__Level, __Fmt),
-        ?__maybe_log(__Level, fun() -> ?HUT_CUSTOM_CB:log(__Level, __Fmt, [], []) end)).
+        ?__maybe_log(__Level, fun() -> ?HUT_CUSTOM_CB:log(__Level, __Fmt, [], [{module, ?MODULE}, {line, ?LINE}, {function_name, ?FUNCTION_NAME}, {function_arity, ?FUNCTION_ARITY}]) end)).
 -define(log(__Level, __Fmt, __Args),
-        ?__maybe_log(__Level, fun() -> ?HUT_CUSTOM_CB:log(__Level, __Fmt, __Args, []) end)).
+        ?__maybe_log(__Level, fun() -> ?HUT_CUSTOM_CB:log(__Level, __Fmt, __Args, [{module, ?MODULE}, {line, ?LINE}, {function_name, ?FUNCTION_NAME}, {function_arity, ?FUNCTION_ARITY}]) end)).
 -define(log(__Level, __Fmt, __Args, __Opts),
-        ?__maybe_log(__Level, fun() -> ?HUT_CUSTOM_CB:log(__Level, __Fmt, __Args, __Opts) end)).
+        ?__maybe_log(__Level, fun() -> ?HUT_CUSTOM_CB:log(__Level, __Fmt, __Args, [{module, ?MODULE}, {line, ?LINE}, {function_name, ?FUNCTION_NAME}, {function_arity, ?FUNCTION_ARITY} | __Opts]) end)).
 
 -endif.
 -else.


### PR DESCRIPTION
These changes provide the missing preprocessor information about the context of the log call.  The data may be ignored by the HUT_CUSTOM_CB module, but there is no other way to get the information when using hut with the current HUT_CUSTOM_CB functions.  The FUNCTION_NAME/FUNCTION_ARITY checks are to handle their absence in Erlang/OTP < 19.0 .